### PR TITLE
Mohr Coulomb changes

### DIFF
--- a/docs/web/MohrCoulomb.md
+++ b/docs/web/MohrCoulomb.md
@@ -90,15 +90,17 @@ where
 K(\theta) = \begin{cases}
 	\cos \theta - \frac{1}{\sqrt{3}} \sin \phi \sin \theta & |\theta| < \theta_\mathrm{T}
 	\\ 
-	A - B \sin 3\theta &  |\theta| \geq \theta_\mathrm{T}
+	A + B \sin 3\theta  + C \sin^2 3 \theta &  |\theta| \geq \theta_\mathrm{T}
 \end{cases}
 \]{#eq:K_abbo}
 
 \[
 \begin{aligned}
-	A &= \frac{1}{3} \cos \theta_\mathrm{T} \left[ 3 + \tan \theta_\mathrm{T} \tan 3\theta_\mathrm{T} + \frac{1}{\sqrt{3}} \mathrm{sign \theta} \, (\tan 3\theta_\mathrm{T} - 3\tan \theta_\mathrm{T}) \sin \phi \right] \\
+	A &= - \frac{1}{\sqrt{3}} \sin \phi \mathrm{sign \theta} \sin \theta_\mathrm{T} - B \mathrm{sign \theta} \sin \theta_\mathrm{T} - C \sin^2 3\theta_\mathrm{T} + \cos \theta_\mathrm{T}\\
 	%
-	B &= \frac{1}{3} \frac{1}{\cos 3\theta_\mathrm{T}} \left[ \mathrm{sign \theta} \, \sin \theta_\mathrm{T} + \frac{1}{\sqrt{3}} \sin \phi \cos \theta_\mathrm{T} \right]
+	B &= \frac{\mathrm{sign \theta} \sin 6\theta_\mathrm{T} \left( \cos \theta_\mathrm{T} - \frac{1}{\sqrt{3} \sin \phi \mathrm{sign \theta} \sin \theta_\mathrm{T}} \right) - 6 \cos 6\theta_\mathrm{T} \left( \mathrm{sign \theta}  \sin \theta_\mathrm{T} + \frac{1}{\sqrt{3} \sin \phi \cos \theta_\mathrm{T}} \right) }{18 \cos^3 3 \theta_\mathrm{T}}\\
+  %
+  C &= \frac{-\cos 3 \theta_\mathrm{T} \left( \cos \theta_\mathrm{T} - \frac{1}{\sqrt{3} \sin \phi \mathrm{sign \theta} \sin \theta_\mathrm{T}} \right) - 3 \mathrm{sign \theta} \sin 3 \theta_\mathrm{T} \left( \mathrm{sign \theta}  \sin \theta_\mathrm{T} + \frac{1}{\sqrt{3} \sin \phi \cos \theta_\mathrm{T}} \right) }{18 \cos^3 3 \theta_\mathrm{T}}
 \end{aligned}
 \]{#eq:Sloan}
 
@@ -138,15 +140,17 @@ with the dilatancy angle :
 K_G(\theta) = \begin{cases}
 	\cos \theta - \frac{1}{\sqrt{3}} \sin \psi \sin \theta & |\theta| < \theta_\mathrm{T}
 	\\ 
-	A_G - B_G \sin 3\theta &  |\theta| \geq \theta_\mathrm{T}
+	A_G + B_G \sin 3\theta  + C_G \sin^2 3 \theta &  |\theta| \geq \theta_\mathrm{T}
 \end{cases}
 \]
 
 \[
 \begin{aligned}
-	A_G &= \frac{1}{3} \cos \theta_\mathrm{T} \left[ 3 + \tan \theta_\mathrm{T} \tan 3\theta_\mathrm{T} + \frac{1}{\sqrt{3}} \mathrm{sign \theta} \, (\tan 3\theta_\mathrm{T} - 3\tan \theta_\mathrm{T}) \sin \psi \right] \\
+	A_G &= - \frac{1}{\sqrt{3}} \sin \psi \mathrm{sign \theta} \sin \theta_\mathrm{T} - B \mathrm{sign \theta} \sin \theta_\mathrm{T} - C \sin^2 3\theta_\mathrm{T} + \cos \theta_\mathrm{T}\\
 	%
-	B_G &= \frac{1}{3} \frac{1}{\cos 3\theta_\mathrm{T}} \left[ \mathrm{sign \theta} \sin \theta_\mathrm{T} + \frac{1}{\sqrt{3}} \sin \psi \cos \theta_\mathrm{T} \right]
+	B_G &= \frac{\mathrm{sign \theta} \sin 6\theta_\mathrm{T} \left( \cos \theta_\mathrm{T} - \frac{1}{\sqrt{3} \sin \psi \mathrm{sign \theta} \sin \theta_\mathrm{T}} \right) - 6 \cos 6\theta_\mathrm{T} \left( \mathrm{sign \theta}  \sin \theta_\mathrm{T} + \frac{1}{\sqrt{3} \sin \psi \cos \theta_\mathrm{T}} \right) }{18 \cos^3 3 \theta_\mathrm{T}}\\
+  %
+  C_G &= \frac{-\cos 3 \theta_\mathrm{T} \left( \cos \theta_\mathrm{T} - \frac{1}{\sqrt{3} \sin \psi \mathrm{sign \theta} \sin \theta_\mathrm{T}} \right) - 3 \mathrm{sign \theta} \sin 3 \theta_\mathrm{T} \left( \mathrm{sign \theta}  \sin \theta_\mathrm{T} + \frac{1}{\sqrt{3} \sin \psi \cos \theta_\mathrm{T}} \right) }{18 \cos^3 3 \theta_\mathrm{T}}
 \end{aligned}
 \]
 
@@ -402,6 +406,8 @@ if true, plastic loading
 @LocalVariable real tan_lodeT;
 @LocalVariable real cos_3_lodeT;
 @LocalVariable real sin_3_lodeT;
+@LocalVariable real cos_6_lodeT;
+@LocalVariable real sin_6_lodeT;
 @LocalVariable real tan_3_lodeT;
 @LocalVariable real a_G;
 ~~~~
@@ -434,6 +440,8 @@ First, we define some variables :
   tan_lodeT = tan(lodeT);
   cos_3_lodeT = cos(3. * lodeT);
   sin_3_lodeT = sin(3. * lodeT);
+  cos_6_lodeT = cos(6. * lodeT);
+  sin_6_lodeT = sin(6. * lodeT);
   tan_3_lodeT = tan(3. * lodeT);
   a_G = (a * tan(phi)) / tan(psi)
 ~~~~
@@ -476,12 +484,18 @@ K is initiliazed as \(K^{el}\) value:
   } else {
     const auto sign =
         min(max(lode_el / max(abs(lode_el), local_zero_tolerance), -1.), 1.);
-    const auto A = 1. / 3. * cos_lodeT *
-                   (3. + tan_lodeT * tan_3_lodeT +
-                    isqrt3 * sign * (tan_3_lodeT - 3. * tan_lodeT) * sin_phi);
-    const auto B = 1 / (3. * cos_3_lodeT) *
-                   (sign * sin_lodeT + isqrt3 * sin_phi * cos_lodeT);
-    K = A - B * arg;
+    const auto term1 = cos_lodeT - isqrt3 * sin_phi * sin_lodeT;
+    const auto term2 = sign * sin_lodeT + isqrt3 * sin_phi * cos_lodeT;
+    const auto term3 = 18. * cos_3_lodeT * cos_3_lodeT * cos_3_lodeT;
+        
+    const auto B = ( sign * sin_6_lodeT * term1 - 
+      6. * cos_6_lodeT * term2 ) / term3; 
+    const auto C = (- cos_3_lodeT * term1 - 3. * sign * sin_3_lodeT * term2) / term3; 
+    
+    const auto A =          
+        -isqrt3 * sin_phi * sign * sin_lodeT - B * sign * sin_3_lodeT - 
+        C * sin_3_lodeT*sin_3_lodeT + cos_lodeT;
+    K = A + B * arg + C * arg*arg;
   }
 ~~~~
 
@@ -536,6 +550,8 @@ if (F) {
     const auto cos_lode = cos(lode);
     const auto sin_lode = sin(lode);
     const auto cos_3_lode = cos(3. * lode);
+    const auto sin_6_lode = sin(6. * lode);
+    const auto cos_6_lode = cos(6. * lode);
     const auto sin_3_lode = arg;
     const auto tan_3_lode = tan(3. * lode);
     auto K = 0.;
@@ -546,13 +562,19 @@ if (F) {
     } else {
       const auto sign =
           min(max(lode / max(abs(lode), local_zero_tolerance), -1.), 1.);
-      const auto A = 1. / 3. * cos_lodeT *
-                     (3. + tan_lodeT * tan_3_lodeT +
-                      isqrt3 * sign * (tan_3_lodeT - 3. * tan_lodeT) * sin_phi);
-      const auto B = 1. / (3. * cos_3_lodeT) *
-                     (sign * sin_lodeT + isqrt3 * sin_phi * cos_lodeT);
-      K = A - B * sin_3_lode;
-      dK_dlode = -3. * B * cos_3_lode;
+      const auto term1 = cos_lodeT - isqrt3 * sin_phi * sin_lodeT;
+      const auto term2 = sign * sin_lodeT + isqrt3 * sin_phi * cos_lodeT;
+      const auto term3 = 18. * cos_3_lodeT * cos_3_lodeT * cos_3_lodeT;
+          
+      const auto B = ( sign * sin_6_lodeT * term1 - 
+        6. * cos_6_lodeT * term2 ) / term3; 
+      const auto C = (- cos_3_lodeT * term1 - 3. * sign * sin_3_lodeT * term2) / term3; 
+      
+      const auto A =          
+          -isqrt3 * sin_phi * sign * sin_lodeT - B * sign * sin_3_lodeT - 
+          C * sin_3_lodeT*sin_3_lodeT + cos_lodeT;
+      K = A + B * sin_3_lode + C * sin_3_lode*sin_3_lode;
+          dK_dlode = 3. * B * cos_3_lode + 3. * C * sin_6_lode;
     }
 ~~~~
 
@@ -573,14 +595,20 @@ if (F) {
     {
       const auto sign =
           min(max(lode / max(abs(lode), local_zero_tolerance), -1.), 1.);
-      const auto A = 1. / 3. * cos_lodeT *
-                     (3. + tan_lodeT * tan_3_lodeT +
-                      isqrt3 * sign * (tan_3_lodeT - 3. * tan_lodeT) * sin_psi);
-      const auto B = 1. / (3. * cos_3_lodeT) *
-                     (sign * sin_lodeT + isqrt3 * sin_psi * cos_lodeT);
-      KG = A - B * sin_3_lode;
-      dKG_dlode = -3. * B * cos_3_lode;
-      dKG_ddlode = 9. * B * sin_3_lode;
+      const auto term1 = cos_lodeT - isqrt3 * sin_psi * sin_lodeT;
+      const auto term2 = sign * sin_lodeT + isqrt3 * sin_psi * cos_lodeT;
+      const auto term3 = 18. * cos_3_lodeT * cos_3_lodeT * cos_3_lodeT;
+          
+      const auto B = ( sign * sin_6_lodeT * term1 - 
+        6. * cos_6_lodeT * term2 ) / term3; 
+      const auto C = (- cos_3_lodeT * term1 - 3. * sign * sin_3_lodeT * term2) / term3; 
+      
+      const auto A =          
+          -isqrt3 * sin_psi * sign * sin_lodeT - B * sign * sin_3_lodeT - 
+          C * sin_3_lodeT*sin_3_lodeT + cos_lodeT;
+          KG = A + B * sin_3_lode + C * sin_3_lode * sin_3_lode;
+          dKG_dlode = 3. * B * cos_3_lode + 3. * C * sin_6_lode;
+          dKG_ddlode = -9. * B * sin_3_lode + 18. * C * cos_6_lode;
     }
 ~~~~
  

--- a/docs/web/bibliography.bib
+++ b/docs/web/bibliography.bib
@@ -526,6 +526,24 @@ Comparative studies of monitoring data and simulations showed good agreement bet
 	file = {Singh et al. - 2019 - Brittle Fracture Model Parameter Estimation for Ir.pdf:/home/th202608/.zotero/zotero/vzpzva46.default/zotero/storage/SNGJQWW5/Singh et al. - 2019 - Brittle Fracture Model Parameter Estimation for Ir.pdf:application/pdf;Snapshot:/home/th202608/.zotero/zotero/vzpzva46.default/zotero/storage/LJEG4I24/2306.html:text/html}
 }
 
+@article{Abbo2011,
+abstract = {In spite of the development of more sophisticated constitutive models for soil, the Mohr-Coulomb yield criterion remains a popular choice for geotechnical analysis due to its simplicity and ease of use by practising engineers. The implementation of the criterion in finite element programs, however, presents some numerical difficulties due to the gradient discontinuities which occur at both the edges and the tip of the hexagonal yield surface pyramid. Furthermore, some implicit techniques utilising consistent tangent stiffness formulations are unable to achieve full quadratic convergence as the yield criteria is not C2 continuous. This paper extends the previous work of Abbo and Sloan (1995) through the introduction of C2 continuous rounding of the Mohr-Coulomb yield surface in the octahedral plane. This approximation, when combined with the hyperbolic approximation in the meridional plane (Abbo and Sloan, 1995), describes a yield surface that is C2 continuous at all stress states. The new smooth yield surface can be made to approximate the Mohr-Coulomb yield function as closely as required by adjusting only two parameters, and is suitable for consistent tangent stiffness formulations. {\textcopyright} 2011 Elsevier Ltd. All rights reserved.},
+author = {Abbo, A.J. and Lyamin, A.V. and Sloan, S.W. and Hambleton, J.P.},
+doi = {10.1016/j.ijsolstr.2011.06.021},
+issn = {00207683},
+journal = {International Journal of Solids and Structures},
+keywords = {Consistent tangent,Elastoplasticity,Finite element,Mohr-Coulomb},
+month = {oct},
+number = {21},
+pages = {3001--3010},
+publisher = {Elsevier Ltd},
+title = {{A C2 continuous approximation to the Mohr–Coulomb yield surface}},
+url = {http://dx.doi.org/10.1016/j.ijsolstr.2011.06.021 https://linkinghub.elsevier.com/retrieve/pii/S0020768311002381},
+volume = {48},
+year = {2011}
+}
+
+
 @article{Abbo1995,
 abstract = {The Mohr-Coulomb yield ceriterion is used widely in elastoplastic geotechnical analysis. there arecomputationaldeficulties with this midel, however, due to the gradient discontinuities which occur at both the edge and the tip of hexagonal yield surface pyramid. It is well known that these singularities often cause stress integration schemes to perform inefficiently or fail. This paper describes a simple hyperbolic surface can be generalized to a family of Mohr-Coulomb yield crietria which are also rounded in the octahedral plane, thus eliminating the singularities that occur at the edge intersections as well. This type of yield surface is both continuous and differentiable at all stress states, and can be made to approximate the Mohr-Coulomb yield function as closely as required by adjusting two parameters. The yield surface and its gradients are presented in a form which is suitable for finite element programming with either explicit or implicit stress intergration schemes. Two efficient FORTRAN 77 subroutines are given to illustrate how the yield surafce can be implemented in practice.},
 author = {Abbo, A.J. and Sloan, S.W.},

--- a/docs/web/release-notes-4.0.md
+++ b/docs/web/release-notes-4.0.md
@@ -18,3 +18,9 @@ eqnPrefixTemplate: "($$i$$)"
 ---
 
 # Tickets fixed
+
+# Changes to existing models
+
+## Mohr Coulomb Abbo Sloan
+
+- The corner smoothing of the Mohr Coulomb surface in the deviatoric plane is changed from the C1-continuous version (Abbo and Sloan, 1995) to the C2-continuous version from Abbo et al., 2011.

--- a/include/TFEL/Material/MohrCoulombYieldCriterion.hxx
+++ b/include/TFEL/Material/MohrCoulombYieldCriterion.hxx
@@ -102,6 +102,10 @@ namespace tfel {
       //! \brief sine of 3*lodeT
       real sin_3_lodeT;
       //! \brief tangent of 3*lodeT
+      real cos_6_lodeT;
+      //! \brief sine of 3*lodeT
+      real sin_6_lodeT;
+      //! \brief tangent of 3*lodeT
       real tan_3_lodeT;
     };  // end of struct MohrCoulombParameters
 


### PR DESCRIPTION
Alterations to surface smoothing procedure in order to make yield function C2 continuous. I tried to catch everything but when I compiled TFEL it didn't seem to recognise the changes (nothing to do during compile); so I'm not sure whether it compiles. Maybe you can take a look.

Similar merge request pending in OGS, tests there run. 