### PR TITLE
Manage computeMeanValue in the same way as computeIntegralValue

### DIFF
--- a/mtest/include/MTest/PipeTest.hxx
+++ b/mtest/include/MTest/PipeTest.hxx
@@ -362,6 +362,7 @@ namespace mtest {
      * \brief compute the integral value of a scalar variable
      * \param[in] s: structure state
      * \param[in] n: variable name
+     * \param[in] c: enum element to choose the initial or final configuration
      */
     virtual real computeIntegralValue(
         const StudyCurrentState&,
@@ -387,6 +388,16 @@ namespace mtest {
     virtual real computeMeanValue(
         const StudyCurrentState&,
         const std::string&,
+        const Configuration = Configuration::INTIAL_CONFIGURATION) const;
+    /*!
+     * \brief compute the mean value of a scalar variable
+     * \param[in] s: structure state
+     * \param[in] n: variable name
+     * \param[in] c: enum element to choose the initial or final configuration
+     */
+    virtual real computeMeanValue(
+        const StudyCurrentState&,
+        const std::function<real(const mtest::CurrentState&)>&,
         const Configuration = Configuration::INTIAL_CONFIGURATION) const;
     /*!
      * \brief add a test comparing to results stored in a reference

--- a/mtest/src/PipeTest.cxx
+++ b/mtest/src/PipeTest.cxx
@@ -1770,6 +1770,13 @@ namespace mtest {
     return this->computeMinimumAndMaximumValues(state, e).second;
   }  // end of computeMaximumValue
 
+  real PipeTest::computeMeanValue(const StudyCurrentState& state,
+                                  const std::string& n,
+                                  const Configuration c) const {
+    auto g = buildValueExtractor(*(this->b), n);
+    return this->computeMeanValue(state, g, c);
+  }  // end of computeIntegralValue
+
   real PipeTest::computeIntegralValue(const StudyCurrentState& state,
                                       const std::string& n,
                                       const Configuration c) const {
@@ -1810,9 +1817,10 @@ namespace mtest {
     }
   }  // end of computeIntegralValue
 
-  real PipeTest::computeMeanValue(const StudyCurrentState& state,
-                                  const std::string& n,
-                                  const Configuration c) const {
+  real PipeTest::computeMeanValue(
+      const StudyCurrentState& state,
+      const std::function<real(const mtest::CurrentState&)>& e,
+      const Configuration c) const {
     constexpr real pi = 3.14159265358979323846;
     const auto ri = [this, state, c]() -> real {
       if ((!this->hpp) && (c == Configuration::CURRENT_CONFIGURATION)) {
@@ -1836,7 +1844,7 @@ namespace mtest {
       return 1.;
     }();
     const auto V = pi * h * (re * re - ri * ri);
-    return this->computeIntegralValue(state, n, c) / V;
+    return this->computeIntegralValue(state, e, c) / V;
   }  // end of computeMeanValue
 
   void PipeTest::addProfile(const std::string& f,


### PR DESCRIPTION
computeMeanValue and computeIntegralValue was not managed in the same way
closes #175 