### PR TITLE
Add Ansys to the homepage list

### DIFF
--- a/docs/web/index.md
+++ b/docs/web/index.md
@@ -81,6 +81,8 @@ A set of interfaces are provided for various solvers:
   [`CalculiX`](http://www.calculix.de/)
   finite element solver. This interface is described
   [here](calculix.html).
+- the [`ANSYS Mechanical APDL`](https://www.ansys.com/) finite element
+  solver. This interface is described [here](ansys.html).
 - the [`ZeBuLoN`](http://www.zset-software.com/products/zebulon)
   finite element solver. This interface is described [here](zmat.html).
 - the `TMFFT` and the


### PR DESCRIPTION
Hi Thomas,

I have been meaning to do this simple PR for a long time but never got around doing it. I personally do not use Ansys, but I think it will give MFront a bit more visibility to new visitors if Ansys is present in the homepage list.

Also, thank you for letting user expressions inside behavioral bricks! That perfectly solves my Norton creep modelling needs.

Best regards,
Fer