### PR TITLE
Replace std::result_of with std::invoke_result_t

### DIFF
--- a/include/TFEL/Math/Stensor/stensor.ixx
+++ b/include/TFEL/Math/Stensor/stensor.ixx
@@ -278,7 +278,7 @@ namespace tfel::math {
 
   template <unsigned short N, typename T>
   template <typename Function>
-  stensor<N, typename std::result_of<Function(T)>::type>
+  stensor<N, typename std::invoke_result_t<Function, T>::type>
   stensor<N, T>::computeIsotropicFunction(const Function& f,
                                           const tvector<3u, T>& vp,
                                           const rotation_matrix<T>& m) {
@@ -295,14 +295,14 @@ namespace tfel::math {
 
   template <unsigned short N, typename T>
   template <typename Function, typename FunctionDerivative>
-  st2tost2<N, typename std::result_of<FunctionDerivative(T)>::type>
+  st2tost2<N, typename std::invoke_result_t<FunctionDerivative, T>::type>
   stensor<N, T>::computeIsotropicFunctionDerivative(
       const Function& f,
       const FunctionDerivative& df,
       const tvector<3u, T>& vp,
       const rotation_matrix<T>& m,
       const T eps) {
-    st2tost2<N, typename std::result_of<FunctionDerivative(T)>::type> r;
+    st2tost2<N, typename std::invoke_result_t<FunctionDerivative, T>::type> r;
     stensor<N, T>::computeIsotropicFunctionDerivative(r, f, df, vp, m, eps);
     return r;
   }  // end of stensor<N,T>::computeIsotropicFunctionDerivative
@@ -361,7 +361,7 @@ namespace tfel::math {
 
   template <unsigned short N, typename T>
   template <typename stensor_common::EigenSolver es, typename Function>
-  stensor<N, typename std::result_of<Function(T)>::type>
+  stensor<N, typename std::invoke_result_t<Function, T>::type>
   stensor<N, T>::computeIsotropicFunction(const Function& f,
                                           const bool b) const {
     using base = base_type<T>;
@@ -376,7 +376,7 @@ namespace tfel::math {
   template <typename stensor_common::EigenSolver es,
             typename Function,
             typename FunctionDerivative>
-  st2tost2<N, typename std::result_of<FunctionDerivative(T)>::type>
+  st2tost2<N, typename std::invoke_result_t<FunctionDerivative, T>::type>
   stensor<N, T>::computeIsotropicFunctionDerivative(
       const Function& f,
       const FunctionDerivative& df,
@@ -395,8 +395,8 @@ namespace tfel::math {
   template <typename stensor_common::EigenSolver es,
             typename Function,
             typename FunctionDerivative>
-  std::pair<stensor<N, typename std::result_of<Function(T)>::type>,
-            st2tost2<N, typename std::result_of<FunctionDerivative(T)>::type>>
+  std::pair<stensor<N, typename std::invoke_result_t<Function, T>::type>,
+            st2tost2<N, typename std::invoke_result_t<FunctionDerivative, T>::type>>
   stensor<N, T>::computeIsotropicFunctionAndDerivative(
       const Function& f,
       const FunctionDerivative& df,

--- a/include/TFEL/Math/Vector/tvector.ixx
+++ b/include/TFEL/Math/Vector/tvector.ixx
@@ -103,9 +103,9 @@ namespace tfel::math {
    * \param[in] x: inital value
    */
   template <typename F, typename T, unsigned short N>
-  tvector<N, typename std::result_of<F(T)>::type> map(F f,
+  tvector<N, typename std::invoke_result_t<F, T>::type> map(F f,
                                                       const tvector<N, T>& x) {
-    tvector<N, typename std::result_of<F(T)>::type> r;
+    tvector<N, typename std::invoke_result_t<F, T>::type> r;
     tfel::fsalgo::transform<N>::exe(x.begin(), r.begin(), f);
     return r;
   }  // end of map

--- a/include/TFEL/Math/stensor.hxx
+++ b/include/TFEL/Math/stensor.hxx
@@ -534,7 +534,7 @@ namespace tfel::math {
      * \param[in]  m:   eigenvectors
      */
     template <typename Function>
-    static stensor<N, typename std::result_of<Function(ValueType)>::type>
+    static stensor<N, typename std::invoke_result_t<Function, ValueType>::type>
     computeIsotropicFunction(const Function&,
                              const tvector<3u, ValueType>&,
                              const rotation_matrix<ValueType>&);
@@ -599,7 +599,7 @@ namespace tfel::math {
     template <typename Function, typename FunctionDerivative>
     static st2tost2<
         N,
-        typename std::result_of<FunctionDerivative(ValueType)>::type>
+        typename std::invoke_result_t<FunctionDerivative, ValueType>::type>
     computeIsotropicFunctionDerivative(const Function&,
                                        const FunctionDerivative&,
                                        const tvector<3u, ValueType>&,
@@ -637,7 +637,7 @@ namespace tfel::math {
      * \param[in] b:   if true, refinement of eigen values is performed
      */
     template <EigenSolver = TFELEIGENSOLVER, typename Function>
-    stensor<N, typename std::result_of<Function(ValueType)>::type>
+    stensor<N, typename std::invoke_result_t<Function, ValueType>::type>
     computeIsotropicFunction(const Function&, const bool = false) const;
     /*!
      * \return the derivative of an isotropic function
@@ -650,7 +650,7 @@ namespace tfel::math {
     template <EigenSolver = TFELEIGENSOLVER,
               typename Function,
               typename FunctionDerivative>
-    st2tost2<N, typename std::result_of<FunctionDerivative(ValueType)>::type>
+    st2tost2<N, typename std::invoke_result_t<FunctionDerivative, ValueType>::type>
     computeIsotropicFunctionDerivative(const Function&,
                                        const FunctionDerivative&,
                                        const ValueType,
@@ -667,9 +667,9 @@ namespace tfel::math {
               typename Function,
               typename FunctionDerivative>
     std::pair<
-        stensor<N, typename std::result_of<Function(ValueType)>::type>,
+        stensor<N, typename std::invoke_result_t<Function, ValueType>::type>,
         st2tost2<N,
-                 typename std::result_of<FunctionDerivative(ValueType)>::type>>
+                 typename std::invoke_result_t<FunctionDerivative, ValueType>::type>>
     computeIsotropicFunctionAndDerivative(const Function&,
                                           const FunctionDerivative&,
                                           const ValueType,

--- a/include/TFEL/Math/tvector.hxx
+++ b/include/TFEL/Math/tvector.hxx
@@ -161,7 +161,7 @@ namespace tfel::math {
    * \param[in] x: inital value
    */
   template <typename F, typename T, unsigned short N>
-  tvector<N, typename std::result_of<F(T)>::type> map(F, const tvector<N, T>&);
+  tvector<N, typename std::invoke_result_t<F, T>::type> map(F, const tvector<N, T>&);
   /*!
    * export the given vector to an array of the
    */

--- a/include/TFEL/System/ThreadPool.hxx
+++ b/include/TFEL/System/ThreadPool.hxx
@@ -49,7 +49,7 @@ namespace tfel::system {
      * \param[in] a: arguments passed to the the task
      */
     template <typename F, typename... Args>
-    std::future<ThreadedTaskResult<typename std::result_of<F(Args...)>::type>>
+    std::future<ThreadedTaskResult<typename std::invoke_result_t<F, Args...>::type>>
     addTask(F&&, Args&&...);
     //! \return the number of threads managed by the ppol
     size_type getNumberOfThreads() const;

--- a/include/TFEL/System/ThreadPool.ixx
+++ b/include/TFEL/System/ThreadPool.ixx
@@ -23,9 +23,9 @@ namespace tfel::system {
   struct ThreadPool::Wrapper {
     Wrapper(F&& f_) : f(f_) {}
     template <typename... Args>
-    ThreadedTaskResult<typename std::result_of<F(Args...)>::type> operator()(
+    ThreadedTaskResult<typename std::invoke_result_t<F, Args...>::type> operator()(
         Args&&... args) {
-      using result = typename std::result_of<F(Args...)>::type;
+      using result = typename std::invoke_result_t<F, Args...>::type;
       using apply = typename std::conditional<std::is_same<result, void>::value,
                                               GetVoid, Get<result>>::type;
       ThreadedTaskResult<result> r;
@@ -60,10 +60,10 @@ namespace tfel::system {
 
   // add new work item to the pool
   template <typename F, typename... Args>
-  std::future<ThreadedTaskResult<typename std::result_of<F(Args...)>::type>>
+  std::future<ThreadedTaskResult<typename std::invoke_result_t<F, Args...>::type>>
   ThreadPool::addTask(F&& f, Args&&... a) {
     using return_type =
-        ThreadedTaskResult<typename std::result_of<F(Args...)>::type>;
+        ThreadedTaskResult<typename std::invoke_result_t<F, Args...>::type>;
     using task = std::packaged_task<return_type()>;
     auto t = std::make_shared<task>(
         std::bind(Wrapper<F>(std::forward<F>(f)), std::forward<Args>(a)...));


### PR DESCRIPTION
Replaced `std::result_of` with `std::invoke_result_t` for C++20 compatibility.

`result_of` is [removed in C++20](https://en.cppreference.com/w/cpp/types/result_of). Please note that it seems that only the Apple Clang compiler >= 14 and the Visual Studio compiler (tested with 19) have implemented the removal. Recent versions of GCC and regular Clang still compile `result_of` fine even with `--std=c++20`.

We recently stumbled upon this in our Mac builds of OpenGeoSys. I have locally tested these changes in OpenGeoSys with MFront / TFEL support on Apple clang version 14.0.3 (clang-1403.0.22.14.1).

cc: @endjunction