### PR TITLE
Add PIE for some tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ if(CMAKE_VERSION VERSION_GREATER 3.1.0)
   cmake_policy(SET CMP0053 OLD)
   cmake_policy(SET CMP0054 NEW)
 endif(CMAKE_VERSION VERSION_GREATER 3.1.0)
+if(CMAKE_VERSION VERSION_GREATER 3.14.0)
+  include(CheckPIESupported)
+  check_pie_supported()
+endif(CMAKE_VERSION VERSION_GREATER 3.14.0)
 
 set(TFEL_VERSION_FLAVOUR "" CACHE STRING
   "Append a flavour to the version number")

--- a/mfm-test-generator/src/CMakeLists.txt
+++ b/mfm-test-generator/src/CMakeLists.txt
@@ -36,6 +36,7 @@ if(TFEL_HAVE_MADNEX)
 endif(TFEL_HAVE_MADNEX)
 
 add_executable(mfm-test-generator mfm-test-generator.cxx)
+set_property(TARGET mfm-test-generator PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 target_link_libraries(mfm-test-generator
  PRIVATE
  MFMTestGenerator)

--- a/mfm/src/CMakeLists.txt
+++ b/mfm/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(mfm mfm.cxx)
 target_link_libraries(mfm
   TFELSystem TFELUtilities)
+set_property(TARGET mfm PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 if(TFEL_APPEND_SUFFIX)
   set_target_properties(mfm
     PROPERTIES OUTPUT_NAME "mfm-${TFEL_SUFFIX}")

--- a/mfront-doc/src/CMakeLists.txt
+++ b/mfront-doc/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 # mfront-doc
 add_executable(mfront-doc mfront-doc.cxx
   BehaviourDocumentationGenerator.cxx)
+set_property(TARGET mfront-doc PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 target_include_directories(mfront-doc
   PRIVATE ${PROJECT_SOURCE_DIR}/mfront-doc/include)
 target_link_libraries(mfront-doc

--- a/mfront-query/src/CMakeLists.txt
+++ b/mfront-query/src/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(mfront-query mfront-query.cxx
   MaterialPropertyQuery.cxx
   BehaviourQuery.cxx
   ModelQuery.cxx)
+set_property(TARGET mfront-query PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 target_include_directories(mfront-query 
   PRIVATE "${PROJECT_SOURCE_DIR}/mfront-query/include")
 target_link_libraries(mfront-query

--- a/mfront/src/CMakeLists.txt
+++ b/mfront/src/CMakeLists.txt
@@ -518,6 +518,7 @@ endif(TFEL_HAVE_MADNEX)
 # MFront
 
 add_executable(mfront main.cxx)
+set_property(TARGET mfront PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 target_link_libraries(mfront
   TFELMFront 
   MFrontLogStream

--- a/mtest/src/CMakeLists.txt
+++ b/mtest/src/CMakeLists.txt
@@ -188,6 +188,7 @@ if(TFEL_HAVE_MADNEX)
 endif(TFEL_HAVE_MADNEX)
 
 add_executable(mtest MTestMain.cxx)
+set_property(TARGET mtest PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 if(WIN32 AND enable-static)
   set(mtest_static_link_libraries
     TFELMTest-static

--- a/tfel-check/src/CMakeLists.txt
+++ b/tfel-check/src/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(TFELCheck
   TFELConfig)
 
 add_executable(tfel-check tfel-check.cxx)
+set_property(TARGET tfel-check PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 if(enable-python OR enable-python-bindings)
   target_compile_definitions(tfel-check
     PRIVATE TFEL_PYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}")

--- a/tfel-config/src/CMakeLists.txt
+++ b/tfel-config/src/CMakeLists.txt
@@ -4,6 +4,8 @@ target_include_directories(tfel-config
   PRIVATE ${PROJECT_BINARY_DIR}/tfel-config/include
   PRIVATE ${PROJECT_SOURCE_DIR}/include)
 
+set_property(TARGET tfel-config PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+
 if(TFEL_HAVE_MADNEX)
   target_compile_definitions(tfel-config
     PUBLIC TFEL_HAVE_MADNEX)

--- a/tfel-doc/src/CMakeLists.txt
+++ b/tfel-doc/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(tfel-doc_SOURCES tfel-doc.cxx
 		     MarkdownGenerator.cxx)
 
 add_executable(tfel-doc ${tfel-doc_SOURCES})
+set_property(TARGET tfel-doc PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 target_include_directories(tfel-doc 
   PRIVATE "${PROJECT_SOURCE_DIR}/tfel-doc/include")
 target_link_libraries(tfel-doc

--- a/tfel-unicode-filt/src/CMakeLists.txt
+++ b/tfel-unicode-filt/src/CMakeLists.txt
@@ -4,6 +4,8 @@ target_include_directories(tfel-unicode-filt
 target_link_libraries(tfel-unicode-filt
 	PRIVATE TFELUnicodeSupport TFELUtilities)
 
+set_property(TARGET tfel-unicode-filt PROPERTY POSITION_INDEPENDENT_CODE TRUE)
+
 if(WIN32 AND enable-static)
   set_target_properties(tfel-unicode-filt PROPERTIES COMPILE_FLAGS "-DTFEL_STATIC_BUILD")
   set_target_properties(tfel-unicode-filt PROPERTIES LINK_FLAGS "-static-libgcc -static") 


### PR DESCRIPTION
Position Indenpedent Code is needed to fix compilation

This fixes the following build error at link time:

 relocation R_X86_64_32S against hidden symbol `_ZNKSt5ctypeIcE8do_widenEc' can not be used when making a PIE object

 relocation R_X86_64_32 against symbol `_ZN4tfel6system13SignalManager14printBackTraceEi' can not be used when making a PIE object

This fixes compilation on Fedora 37 with the following CXXFLAGS: -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection