### PR TITLE
document integrator

### DIFF
--- a/docs/web/Default-keywords.md
+++ b/docs/web/Default-keywords.md
@@ -803,17 +803,14 @@ The `@Integrator` keyword allows the user to construct the implicit system to re
 The following conventions apply: 
 — sig represents the updated stress (calculated by the code provided after the @ComputeStress keyword);
 — eto represents the total strain at the start of the time step;
-— deto represents the change in total strain (constant over the time step);
-— dT represents the change in temperature (constant over the time step);
+— deto represents the increment of the total strain (constant over the time step);
+— dT represents the increment of the temperature (constant over the time step);
 — for any internal variable Y, Y represents its value at the start of the time step;
-— for any internal variable Y, Y represents the current estimate of the increment of this variable over the time step;
+— for any internal variable Y, dY represents the current estimate of the increment of this variable over the time step;
 — for any internal variable Y, fY represents the implicit equation associated with this variable;
 — for any auxiliary internal variable Y, Y represents its value at the start of the time step;
 — for any external variable V, V represents its value at the start of the time step;
-— for any external variable V, dV represents its change over the time step (constant over the time step). 
-
-If NEWTON's algorithm or the first BROYDEN algorithm is used, for any pair of internal variables Yi and Yj, dfYi_ddYj represents the Jacobian term ∂fYi ∂Yj;
-
+— for any external variable V, dV represents its increment over the time step (constant over the time step). 
 
 # The `@InteractionMatrix` keyword
 

--- a/docs/web/Default-keywords.md
+++ b/docs/web/Default-keywords.md
@@ -796,7 +796,24 @@ The keyword `@IntegerConstant` is not documented yet
 
 # The `@Integrator` keyword
 
-The keyword `@Integrator` is not documented yet
+The `@Integrator` keyword allows the user to construct the implicit system to resolve.
+
+## Specific conventions 
+
+The following conventions apply: 
+— sig represents the updated stress (calculated by the code provided after the @ComputeStress keyword);
+— eto represents the total strain at the start of the step;
+— deto represents the total strain rate (constant over the step);
+— dT represents the rate of temperature change (constant over time);
+— for any internal variable Y, Y represents its value at the start of the step;
+— for any internal variable Y, Y represents the current estimate of the increment of this variable over the step;
+— for any internal variable Y, fY represents the implicit equation associated with this variable;
+— for any auxiliary internal variable Y, Y represents its value at the start of the step;
+— for any external variable V, V represents its value at the start of the step;
+— for any external variable V, dV represents its rate of change over the time step (constant over the time step). 
+
+If NEWTON's algorithm or the first BROYDEN algorithm is used, for any pair of internal variables Yi and Yj, dfYi_ddYj represents the Jacobian term ∂fYi ∂Yj;
+
 
 # The `@InteractionMatrix` keyword
 

--- a/docs/web/Default-keywords.md
+++ b/docs/web/Default-keywords.md
@@ -802,15 +802,15 @@ The `@Integrator` keyword allows the user to construct the implicit system to re
 
 The following conventions apply: 
 — sig represents the updated stress (calculated by the code provided after the @ComputeStress keyword);
-— eto represents the total strain at the start of the step;
-— deto represents the total strain rate (constant over the step);
-— dT represents the rate of temperature change (constant over time);
-— for any internal variable Y, Y represents its value at the start of the step;
-— for any internal variable Y, Y represents the current estimate of the increment of this variable over the step;
+— eto represents the total strain at the start of the time step;
+— deto represents the change in total strain (constant over the time step);
+— dT represents the change in temperature (constant over the time step);
+— for any internal variable Y, Y represents its value at the start of the time step;
+— for any internal variable Y, Y represents the current estimate of the increment of this variable over the time step;
 — for any internal variable Y, fY represents the implicit equation associated with this variable;
-— for any auxiliary internal variable Y, Y represents its value at the start of the step;
-— for any external variable V, V represents its value at the start of the step;
-— for any external variable V, dV represents its rate of change over the time step (constant over the time step). 
+— for any auxiliary internal variable Y, Y represents its value at the start of the time step;
+— for any external variable V, V represents its value at the start of the time step;
+— for any external variable V, dV represents its change over the time step (constant over the time step). 
 
 If NEWTON's algorithm or the first BROYDEN algorithm is used, for any pair of internal variables Yi and Yj, dfYi_ddYj represents the Jacobian term ∂fYi ∂Yj;
 


### PR DESCRIPTION
I've translated the `@integrator` keyword from 
https://thelfer.github.io/tfel/web/documents/mfront/behaviours.pdf

I've reworded what google translate gave. Could you confirm deto, dT and dV are rates of change, as opposed to change in eto, T or V?

I'll copy the doc for `@integrator` to other the locations it's used once you're happy with the wording.