### PR TITLE
Fix LSDYNA Doxygen documentation

### DIFF
--- a/mfront/include/MFront/LSDYNA/lsdyna.doxygen
+++ b/mfront/include/MFront/LSDYNA/lsdyna.doxygen
@@ -1,11 +1,11 @@
 /*!
- * \file  mfront/include/MFront/Abaqus/abaqus.doxygen
- * \brief This file documents the `abaqus` namespace.
+ * \file  mfront/include/MFront/LSDYNA/lsdyna.doxygen
+ * \brief This file documents the `lsdyna` namespace.
  */
 
 /*!
  * \namespace abaqus
- * \brief the namespace abaqus contains material related to the MFront
- * interface to the `Abaqus/Standard` and `Abaqus/Explicit` finite
- * element solver.
+ * \brief the namespace lsdyna contains material related to the MFront
+ * interface to the [LSDYNA](https://lsdyna.ansys.com/) explicit
+ * finite element solver.
  */


### PR DESCRIPTION
Minor fixes to LSDYNA docs.

I am trying to see if I can get a proof-of-concept of the RADIOSS interface, but I doubt it :)

Also, I noticed the BCC and FCC files are mostly empty. Are those behavioural laws functional? In the case of FCC the crystalline vectors are all commented out but present.

I will keep you updated with my RADIOSS progress.

Best regards,
Fer