### PR TITLE
Remove duplicate release-note 3.2.3 target

### DIFF
--- a/docs/web/CMakeLists.txt
+++ b/docs/web/CMakeLists.txt
@@ -141,7 +141,6 @@ pandoc_html(release-notes-3.2   "--toc" "--toc-depth=2" "--number-sections" "-c 
 pandoc_html(release-notes-3.2.1 "--toc" "--toc-depth=2")
 pandoc_html(release-notes-3.2.2 "--toc" "--toc-depth=2")
 pandoc_html(release-notes-3.2.3 "--toc" "--toc-depth=2")
-pandoc_html(release-notes-3.2.3 "--toc" "--toc-depth=2")
 pandoc_html(release-notes-3.2.4 "--toc" "--toc-depth=2")
 pandoc_html(release-notes-3.2.5 "--toc" "--toc-depth=2")
 pandoc_html(release-notes-3.2.6 "--toc" "--toc-depth=2")


### PR DESCRIPTION
Error triggered after upgrading to cmake-4.0.0.