### PR TITLE
fix macOS ci

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,6 +16,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            jobs_flag: '-j $(nproc)'
+          - os: macos-latest
+            jobs_flag: '-j $(sysctl -n hw.ncpu)'
 
     runs-on: ${{ matrix.os }}
 
@@ -33,22 +38,25 @@ jobs:
 
     - name: Build
       run: |
-        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j $(nproc)
+        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} ${{ matrix.jobs_flag }}
 
     - name: Test
+      run: |
+        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target build-tests ${{ matrix.jobs_flag }}
+        ctest --test-dir ${{github.workspace}}/build --build-config ${{env.BUILD_TYPE}} ${{ matrix.jobs_flag }}
+
+    - name: Collect test results
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target build-tests -j $(nproc)
-        ctest --test-dir ${{github.workspace}}/build --build-config ${{env.BUILD_TYPE}} -j $(nproc)
         mkdir ${{github.workspace}}/tests-results
         cp --parents $(find ${{github.workspace}}/build -path ${{github.workspace}}/build/Testing -prune -o -type f  -name "*.xml" -print) ${{github.workspace}}/tests-results
 
     - name: Install
       run: |
-        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target install -j $(nproc)
+        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target install ${{ matrix.jobs_flag }}
 
     - name: Print test log on failure
-      if: ${{ matrix.os == 'ubuntu-latest' && failure() }}
+      if: ${{ failure() }}
       run: |
         cat ${{github.workspace}}/build/Testing/Temporary/*.log
 
@@ -62,4 +70,4 @@ jobs:
       run: |
         source ${{github.workspace}}/install/share/tfel/env/env.sh
         cd ${{github.workspace}}/install/share/tfel/test-suite
-        tfel-check  -j $(nproc)
+        tfel-check  ${{ matrix.jobs_flag }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -75,6 +75,7 @@ jobs:
     - name: Print tfel-check logs on failure
       if: ${{ failure() }}
       run: |
+        [ -d ${{github.workspace}}/install/share/tfel/test-suite ] || exit 0
         cd ${{github.workspace}}/install/share/tfel/test-suite
         for f in $(grep -rli 'failed' --include='*.checklog' .); do
           d=$(dirname "$f")

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -71,3 +71,18 @@ jobs:
         source ${{github.workspace}}/install/share/tfel/env/env.sh
         cd ${{github.workspace}}/install/share/tfel/test-suite
         tfel-check  ${{ matrix.jobs_flag }}
+
+    - name: Print tfel-check logs on failure
+      if: ${{ failure() }}
+      run: |
+        cd ${{github.workspace}}/install/share/tfel/test-suite
+        for f in $(grep -rli 'failed' --include='*.checklog' .); do
+          d=$(dirname "$f")
+          echo "==== $f"
+          cat "$f"
+          for o in "$d"/*.out; do
+            [ -e "$o" ] || continue
+            echo "---- $o"
+            cat "$o"
+          done
+        done

--- a/.github/workflows/tdls.yml
+++ b/.github/workflows/tdls.yml
@@ -16,6 +16,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            jobs_flag: '-j $(nproc)'
+          - os: macos-latest
+            jobs_flag: '-j $(sysctl -n hw.ncpu)'
 
     runs-on: ${{ matrix.os }}
 
@@ -37,8 +42,8 @@ jobs:
               -B ${{github.workspace}}/build-tdls                       \
               -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}                    \
               -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/install-tdls
-        cmake --build ${{github.workspace}}/build-tdls --config ${{env.BUILD_TYPE}} -j $(nproc)
-        cmake --build ${{github.workspace}}/build-tdls --config ${{env.BUILD_TYPE}} --target install -j $(nproc)
+        cmake --build ${{github.workspace}}/build-tdls --config ${{env.BUILD_TYPE}} ${{ matrix.jobs_flag }}
+        cmake --build ${{github.workspace}}/build-tdls --config ${{env.BUILD_TYPE}} --target install ${{ matrix.jobs_flag }}
 
     - name: Configure CMake
       run: |
@@ -52,22 +57,25 @@ jobs:
 
     - name: Build
       run: |
-        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} -j $(nproc)
+        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} ${{ matrix.jobs_flag }}
 
     - name: Test
+      run: |
+        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target build-tests ${{ matrix.jobs_flag }}
+        ctest --test-dir ${{github.workspace}}/build --build-config ${{env.BUILD_TYPE}} ${{ matrix.jobs_flag }}
+
+    - name: Collect test results
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target build-tests -j $(nproc)
-        ctest --test-dir ${{github.workspace}}/build --build-config ${{env.BUILD_TYPE}} -j $(nproc)
         mkdir ${{github.workspace}}/tests-results
         cp --parents $(find ${{github.workspace}}/build -path ${{github.workspace}}/build/Testing -prune -o -type f  -name "*.xml" -print) ${{github.workspace}}/tests-results
 
     - name: Install
       run: |
-        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target install -j $(nproc)
+        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target install ${{ matrix.jobs_flag }}
 
     - name: Print test log on failure
-      if: ${{ matrix.os == 'ubuntu-latest' && failure() }}
+      if: ${{ failure() }}
       run: |
         cat ${{github.workspace}}/build/Testing/Temporary/*.log
 
@@ -81,4 +89,4 @@ jobs:
       run: |
         source ${{github.workspace}}/install/share/tfel/env/env.sh
         cd ${{github.workspace}}/install/share/tfel/test-suite
-        tfel-check  -j $(nproc)
+        tfel-check  ${{ matrix.jobs_flag }}

--- a/.github/workflows/tdls.yml
+++ b/.github/workflows/tdls.yml
@@ -94,6 +94,7 @@ jobs:
     - name: Print tfel-check logs on failure
       if: ${{ failure() }}
       run: |
+        [ -d ${{github.workspace}}/install/share/tfel/test-suite ] || exit 0
         cd ${{github.workspace}}/install/share/tfel/test-suite
         for f in $(grep -rli 'failed' --include='*.checklog' .); do
           d=$(dirname "$f")

--- a/.github/workflows/tdls.yml
+++ b/.github/workflows/tdls.yml
@@ -90,3 +90,18 @@ jobs:
         source ${{github.workspace}}/install/share/tfel/env/env.sh
         cd ${{github.workspace}}/install/share/tfel/test-suite
         tfel-check  ${{ matrix.jobs_flag }}
+
+    - name: Print tfel-check logs on failure
+      if: ${{ failure() }}
+      run: |
+        cd ${{github.workspace}}/install/share/tfel/test-suite
+        for f in $(grep -rli 'failed' --include='*.checklog' .); do
+          d=$(dirname "$f")
+          echo "==== $f"
+          cat "$f"
+          for o in "$d"/*.out; do
+            [ -e "$o" ] || continue
+            echo "---- $o"
+            cat "$o"
+          done
+        done

--- a/mfront/src/MakefileGenerator.cxx
+++ b/mfront/src/MakefileGenerator.cxx
@@ -599,7 +599,7 @@ namespace mfront {
         m << "-shared -Wl,--add-stdcall-alias,--out-implib,cyg" << l.name
           << "_dll.a,-no-undefined ";
       } else if (o.sys == "apple") {
-        m << "-bundle ";
+        m << "-bundle -Wl,-headerpad_max_install_names ";
       } else {
         m << "-shared ";
       }


### PR DESCRIPTION
Closes https://github.com/thelfer/tfel/issues/1028 .  Parallelism flag is now defined per-OS with a build matrix. This way, on macos we use `sysctl -n hw.ncpu` instead of the broken `nproc` . macOS tests re enabled